### PR TITLE
Fix Prometheus scraper config for ceph monitors

### DIFF
--- a/prometheus/prometheus.yml.d/50-ceph.yml
+++ b/prometheus/prometheus.yml.d/50-ceph.yml
@@ -4,7 +4,7 @@ scrape_configs:
     static_configs:
       - targets:
 {% for host in groups['mons'] %}
-        - "{{ admin_oc_net_name | net_ip(host) }}:9283"
+        - "{{ hostvars[host]['ansible_' + hostvars[host]['storage_interface']]['ipv4']['address'] }}:9283"
 {% endfor %}
     scrape_interval: 15s
 {% endif %}

--- a/prometheus/prometheus.yml.d/51-ceph-nodeexporter.yml
+++ b/prometheus/prometheus.yml.d/51-ceph-nodeexporter.yml
@@ -4,6 +4,6 @@ scrape_configs:
     static_configs:
       - targets:
 {% for host in groups['ceph'] %}
-        - "{{ admin_oc_net_name | net_ip(host) }}:9100"
+        - "{{ api_interface_address }}:9100"
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
Use Ansible inventory variables to specify the ceph monitor nodes

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>