### PR TITLE
Remove Rabbitmq rule file for Prometheus

### DIFF
--- a/prometheus/prometheus.yml.d/10-rabbitmq.yml
+++ b/prometheus/prometheus.yml.d/10-rabbitmq.yml
@@ -1,9 +1,0 @@
-
-scrape_configs:
-  - job_name: rabbitmq
-    static_configs:
-      - targets:
-{% for host in groups['rabbitmq'] %}
-        - '{{ 'api' | kolla_address(host) | put_address_in_context('url') }}:15692'
-{% endfor %}
-


### PR DESCRIPTION
kolla-ansible provides a `rabbitmq` rule already. The redundant
definition makes prometheus_server failing to start.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>