### PR TITLE
Remove alertmanager rule file for Prometheus

### DIFF
--- a/prometheus/prometheus.yml.d/60-alertmanager.yml
+++ b/prometheus/prometheus.yml.d/60-alertmanager.yml
@@ -1,9 +1,0 @@
-
-scrape_configs:
-  - job_name: alertmanager
-    static_configs:
-      - targets:
-{% for host in groups['prometheus-alertmanager'] %}
-        - "{{ 'api' | kolla_address(host) | put_address_in_context('url') }}:{{ prometheus_alertmanager_port }}"
-{% endfor %}
-


### PR DESCRIPTION
kolla-ansible provides a `alertmanager` rule already. The redundant
definition makes prometheus_server failing to start.

Signed-off-by: Uwe Grawert <grawert@b1-systems.de>