### PR TITLE
Update dashboards and prometheus rules

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -6,6 +6,7 @@ rules:
   line-length: disable
 
 ignore: |
+  prometheus/prometheus.yml.d/60-fluentd-aggregator.yml
   prometheus/prometheus.yml.d/51-ceph-nodeexporter.yml
   prometheus/prometheus.yml.d/50-ceph.yml
   prometheus/prometheus.yml.d/10-redfish.yml

--- a/grafana/dashboards/ceph/ceph-cluster-advanced.json
+++ b/grafana/dashboards/ceph/ceph-cluster-advanced.json
@@ -3642,6 +3642,285 @@
             }
          ],
          "type": "table"
+      },
+      {
+         "aliasColors": {},
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "description": "",
+         "editable": true,
+         "error": false,
+         "fill": 1,
+         "fillGradient": 0,
+         "grid": {},
+         "gridPos": {
+            "h": 10,
+            "w": 24,
+            "x": 0,
+            "y": 41
+         },
+         "hiddenSeries": false,
+         "id": 43,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "sort": "avg",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 2,
+         "links": [],
+         "nullPointMode": "connected",
+         "options": {
+            "dataLinks": []
+         },
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "seriesOverrides": [
+            {
+               "alias": "/^Total.*$/",
+               "stack": false
+            }
+         ],
+         "spaceLength": 10,
+         "stack": true,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "ceph_pg_active",
+               "format": "time_series",
+               "hide": true,
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Active",
+               "refId": "M"
+            },
+            {
+               "expr": "ceph_pg_clean",
+               "format": "time_series",
+               "hide": true,
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Clean",
+               "refId": "U"
+            },
+            {
+               "expr": "ceph_pg_peering",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Peering",
+               "refId": "I"
+            },
+            {
+               "expr": "ceph_pg_degraded",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Degraded",
+               "refId": "B",
+               "step": 300
+            },
+            {
+               "expr": "ceph_pg_stale",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Stale",
+               "refId": "C",
+               "step": 300
+            },
+            {
+               "expr": "ceph_unclean_pgs",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Unclean",
+               "refId": "D",
+               "step": 300
+            },
+            {
+               "expr": "ceph_pg_undersized",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Undersized",
+               "refId": "E",
+               "step": 300
+            },
+            {
+               "expr": "ceph_pg_incomplete",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Incomplete",
+               "refId": "G"
+            },
+            {
+               "expr": "ceph_pg_forced_backfill",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Forced Backfill",
+               "refId": "H"
+            },
+            {
+               "expr": "ceph_pg_inconsistent",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Inconsistent",
+               "refId": "F"
+            },
+            {
+               "expr": "ceph_pg_forced_recovery",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Forced Recovery",
+               "refId": "J"
+            },
+            {
+               "expr": "ceph_pg_creating",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Creating",
+               "refId": "K"
+            },
+            {
+               "expr": "ceph_pg_wait_backfill",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Wait Backfill",
+               "refId": "L"
+            },
+            {
+               "expr": "ceph_pg_deep",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Deep",
+               "refId": "N"
+            },
+            {
+               "expr": "ceph_pg_scrubbing",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Scrubbing",
+               "refId": "O"
+            },
+            {
+               "expr": "ceph_pg_recovering",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Recovering",
+               "refId": "P"
+            },
+            {
+               "expr": "ceph_pg_repair",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Repair",
+               "refId": "Q"
+            },
+            {
+               "expr": "ceph_pg_down",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Down",
+               "refId": "R"
+            },
+            {
+               "expr": "ceph_pg_peered",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Peered",
+               "refId": "S"
+            },
+            {
+               "expr": "ceph_pg_backfill",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Backfill",
+               "refId": "T"
+            },
+            {
+               "expr": "ceph_pg_remapped",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Remapped",
+               "refId": "V"
+            },
+            {
+               "expr": "ceph_pg_backfill_toofull",
+               "format": "time_series",
+               "interval": "$interval",
+               "intervalFactor": 1,
+               "legendFormat": "Backfill Toofull",
+               "refId": "W"
+            }
+         ],
+         "thresholds": [],
+         "timeFrom": null,
+         "timeRegions": [],
+         "timeShift": null,
+         "title": "Bad PGs",
+         "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 1,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+         },
+         "yaxes": [
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": 0,
+               "show": true
+            },
+            {
+               "format": "short",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ],
+         "yaxis": {
+            "align": false,
+            "alignLevel": null
+         }
       }
    ],
    "refresh": "1m",

--- a/grafana/dashboards/ceph/ceph_overview.json
+++ b/grafana/dashboards/ceph/ceph_overview.json
@@ -1,0 +1,2928 @@
+
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "Ceph Cluster overview.\r\n",
+  "editable": true,
+  "gnetId": 2842,
+  "graphTooltip": 0,
+  "id": 97,
+  "iteration": 1616693613290,
+  "links": [],
+  "panels": [
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 37,
+      "panels": [],
+      "repeat": null,
+      "title": "CLUSTER STATE",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 1
+      },
+      "id": 21,
+      "interval": "1m",
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "ceph_health_status",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "1,2",
+      "title": "Status",
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        },
+        {
+          "op": "=",
+          "text": "WARNING",
+          "value": "1"
+        },
+        {
+          "op": "=",
+          "text": "HEALTHY",
+          "value": "0"
+        },
+        {
+          "op": "=",
+          "text": "ERROR",
+          "value": "2"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 1
+      },
+      "id": 14,
+      "interval": "1m",
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(ceph_mon_quorum_status)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "2,3",
+      "title": "Monitors In Quorum",
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 1
+      },
+      "id": 22,
+      "interval": "1m",
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "count(ceph_pool_bytes_used)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "",
+      "title": "Pools",
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "bytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 1
+      },
+      "id": 33,
+      "interval": "1m",
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "ceph_cluster_total_bytes",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "0.025,0.1",
+      "title": "Cluster Capacity",
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "bytes",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 1
+      },
+      "id": 34,
+      "interval": "1m",
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "ceph_cluster_total_used_bytes",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "0.025,0.1",
+      "title": "Used Capacity",
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": 2,
+      "editable": true,
+      "error": false,
+      "format": "percent",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": true,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 1
+      },
+      "id": 23,
+      "interval": "1m",
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "((ceph_cluster_total_bytes-ceph_cluster_total_used_bytes)/ceph_cluster_total_bytes)*100",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "10,30",
+      "title": "Available Capacity",
+      "type": "singlestat",
+      "valueFontSize": "70%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 5
+      },
+      "id": 38,
+      "panels": [],
+      "repeat": null,
+      "title": "OSD STATE",
+      "type": "row"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 0,
+        "y": 6
+      },
+      "id": 26,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(ceph_osd_in)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "",
+      "title": "OSDs IN",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 40, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 2,
+        "y": 6
+      },
+      "id": 27,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "count(ceph_osd_up) - count(ceph_osd_in)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "1,1",
+      "title": "OSDs OUT",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": false,
+      "colors": [
+        "rgba(245, 54, 54, 0.9)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(50, 172, 45, 0.97)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 4,
+        "y": 6
+      },
+      "id": 28,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "sum(ceph_osd_up)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "",
+      "title": "OSDs UP",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": true,
+      "colorValue": false,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 40, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 2,
+        "x": 6,
+        "y": 6
+      },
+      "id": 29,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": false,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": false
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "count(ceph_osd_up == 0) OR vector(0)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "1,1",
+      "title": "OSDs DOWN",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "none",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 8,
+        "y": 6
+      },
+      "id": 30,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg(ceph_osd_numpg)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "250,300",
+      "title": "Agerage PGs per OSD",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "ms",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 12,
+        "y": 6
+      },
+      "id": 31,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg(ceph_osd_apply_latency_ms)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "10,50",
+      "title": "Average OSD Apply Latency",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "ms",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 16,
+        "y": 6
+      },
+      "id": 32,
+      "interval": null,
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg(ceph_osd_commit_latency_ms)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "10,50",
+      "title": "Average OSD Commit Latency",
+      "type": "singlestat",
+      "valueFontSize": "80%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "avg"
+    },
+    {
+      "cacheTimeout": null,
+      "colorBackground": false,
+      "colorValue": true,
+      "colors": [
+        "rgba(50, 172, 45, 0.97)",
+        "rgba(237, 129, 40, 0.89)",
+        "rgba(245, 54, 54, 0.9)"
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "format": "s",
+      "gauge": {
+        "maxValue": 100,
+        "minValue": 0,
+        "show": false,
+        "thresholdLabels": false,
+        "thresholdMarkers": true
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 4,
+        "x": 20,
+        "y": 6
+      },
+      "id": 24,
+      "interval": "1m",
+      "links": [],
+      "mappingType": 1,
+      "mappingTypes": [
+        {
+          "name": "value to text",
+          "value": 1
+        },
+        {
+          "name": "range to text",
+          "value": 2
+        }
+      ],
+      "maxDataPoints": 100,
+      "nullPointMode": "connected",
+      "nullText": null,
+      "options": {},
+      "postfix": "",
+      "postfixFontSize": "50%",
+      "prefix": "",
+      "prefixFontSize": "50%",
+      "rangeMaps": [
+        {
+          "from": "null",
+          "text": "N/A",
+          "to": "null"
+        }
+      ],
+      "repeat": null,
+      "sparkline": {
+        "fillColor": "rgba(31, 118, 189, 0.18)",
+        "full": true,
+        "lineColor": "rgb(31, 120, 193)",
+        "show": true
+      },
+      "tableColumn": "",
+      "targets": [
+        {
+          "expr": "avg(ceph_monitor_latency_seconds)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": "70,80",
+      "title": "Average Monitor Latency",
+      "type": "singlestat",
+      "valueFontSize": "100%",
+      "valueMaps": [
+        {
+          "op": "=",
+          "text": "N/A",
+          "value": "null"
+        }
+      ],
+      "valueName": "current"
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 9
+      },
+      "id": 39,
+      "panels": [],
+      "repeat": null,
+      "title": "CLUSTER",
+      "type": "row"
+    },
+    {
+      "aliasColors": {
+        "Available": "#EAB839",
+        "Total Capacity": "#447EBC",
+        "Used": "#BF1B00",
+        "total_avail": "#6ED0E0",
+        "total_space": "#7EB26D",
+        "total_used": "#890F02"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 4,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 10
+      },
+      "height": "300",
+      "hiddenSeries": false,
+      "id": 1,
+      "interval": "$interval",
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 0,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "Total Capacity",
+          "fill": 0,
+          "linewidth": 3,
+          "stack": false
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ceph_cluster_total_bytes-ceph_cluster_total_used_bytes",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Available",
+          "refId": "A",
+          "step": 300
+        },
+        {
+          "expr": "ceph_cluster_total_used_bytes",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Used",
+          "refId": "B",
+          "step": 300
+        },
+        {
+          "expr": "ceph_cluster_total_bytes",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Total Capacity",
+          "refId": "C",
+          "step": 300
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Capacity",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "bytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {
+        "Total Capacity": "#7EB26D",
+        "Used": "#BF1B00",
+        "total_avail": "#6ED0E0",
+        "total_space": "#7EB26D",
+        "total_used": "#890F02"
+      },
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": 0,
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 10
+      },
+      "height": "300",
+      "hiddenSeries": false,
+      "id": 3,
+      "interval": "$interval",
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(rate(ceph_osd_op_w[$interval]))",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Write",
+          "refId": "A",
+          "step": 300
+        },
+        {
+          "expr": "sum(rate(ceph_osd_op_r[$interval]))",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Read",
+          "refId": "B",
+          "step": 300
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "IOPS",
+      "tooltip": {
+        "msResolution": true,
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "",
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 10
+      },
+      "height": "300",
+      "hiddenSeries": false,
+      "id": 7,
+      "interval": "$interval",
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(ceph_osd_op_w_in_bytes[$interval]))",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Write",
+          "refId": "A",
+          "step": 300
+        },
+        {
+          "expr": "sum(irate(ceph_osd_op_r_out_bytes[$interval]))",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Read",
+          "refId": "B",
+          "step": 300
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Throughput",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "decbytes",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 18
+      },
+      "id": 40,
+      "panels": [],
+      "repeat": null,
+      "title": "LATENCY",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 16,
+        "x": 0,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 35,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(ceph_osd_apply_latency_ms)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 2,
+          "legendFormat": "apply",
+          "metric": "ceph_osd_perf_apply_latency_seconds",
+          "refId": "A",
+          "step": 4
+        },
+        {
+          "expr": "avg(ceph_osd_commit_latency_ms)",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 2,
+          "legendFormat": "commit",
+          "metric": "ceph_osd_perf_commit_latency_seconds",
+          "refId": "B",
+          "step": 4
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "OSD Apply + Commit Latency",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": null,
+          "format": "ms",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "decimals": null,
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 19
+      },
+      "hiddenSeries": false,
+      "id": 36,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "hideEmpty": false,
+        "max": true,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "avg(ceph_monitor_latency_seconds)",
+          "format": "time_series",
+          "interval": "",
+          "intervalFactor": 2,
+          "legendFormat": "latency",
+          "metric": "ceph_monitor_latency_seconds",
+          "refId": "A",
+          "step": 10
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Monitor Latency (Currently not available with Ceph MGR)",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 41,
+      "panels": [],
+      "repeat": null,
+      "title": "OBJECTS",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 27
+      },
+      "hiddenSeries": false,
+      "id": 18,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/^Total.*$/",
+          "stack": false
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ceph_cluster_total_objects",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Total",
+          "refId": "A",
+          "step": 300
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Objects in the Cluster",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 1,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "hiddenSeries": false,
+      "id": 19,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/^Total.*$/",
+          "stack": false
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ceph_pg_active",
+          "format": "time_series",
+          "hide": false,
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Active",
+          "refId": "M"
+        },
+        {
+          "expr": "ceph_pg_clean",
+          "format": "time_series",
+          "hide": false,
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Clean",
+          "refId": "U"
+        },
+        {
+          "expr": "ceph_pg_peering",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Peering",
+          "refId": "I"
+        },
+        {
+          "expr": "ceph_pg_degraded",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Degraded",
+          "refId": "B",
+          "step": 300
+        },
+        {
+          "expr": "ceph_pg_stale",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Stale",
+          "refId": "C",
+          "step": 300
+        },
+        {
+          "expr": "ceph_unclean_pgs",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Unclean",
+          "refId": "D",
+          "step": 300
+        },
+        {
+          "expr": "ceph_pg_undersized",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Undersized",
+          "refId": "E",
+          "step": 300
+        },
+        {
+          "expr": "ceph_pg_incomplete",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Incomplete",
+          "refId": "G"
+        },
+        {
+          "expr": "ceph_pg_forced_backfill",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Forced Backfill",
+          "refId": "H"
+        },
+        {
+          "expr": "ceph_pg_inconsistent",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Inconsistent",
+          "refId": "F"
+        },
+        {
+          "expr": "ceph_pg_forced_recovery",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Forced Recovery",
+          "refId": "J"
+        },
+        {
+          "expr": "ceph_pg_creating",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Creating",
+          "refId": "K"
+        },
+        {
+          "expr": "ceph_pg_wait_backfill",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Wait Backfill",
+          "refId": "L"
+        },
+        {
+          "expr": "ceph_pg_deep",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Deep",
+          "refId": "N"
+        },
+        {
+          "expr": "ceph_pg_scrubbing",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Scrubbing",
+          "refId": "O"
+        },
+        {
+          "expr": "ceph_pg_recovering",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Recovering",
+          "refId": "P"
+        },
+        {
+          "expr": "ceph_pg_repair",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Repair",
+          "refId": "Q"
+        },
+        {
+          "expr": "ceph_pg_down",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Down",
+          "refId": "R"
+        },
+        {
+          "expr": "ceph_pg_peered",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Peered",
+          "refId": "S"
+        },
+        {
+          "expr": "ceph_pg_backfill",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Backfill",
+          "refId": "T"
+        },
+        {
+          "expr": "ceph_pg_remapped",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Remapped",
+          "refId": "V"
+        },
+        {
+          "expr": "ceph_pg_backfill_toofull",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Backfill Toofull",
+          "refId": "W"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "PGs",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 1,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "description": "",
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "fillGradient": 0,
+      "grid": {},
+      "gridPos": {
+        "h": 10,
+        "w": 24,
+        "x": 0,
+        "y": 41
+      },
+      "hiddenSeries": false,
+      "id": 43,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "sort": "avg",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/^Total.*$/",
+          "stack": false
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ceph_pg_active",
+          "format": "time_series",
+          "hide": true,
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Active",
+          "refId": "M"
+        },
+        {
+          "expr": "ceph_pg_clean",
+          "format": "time_series",
+          "hide": true,
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Clean",
+          "refId": "U"
+        },
+        {
+          "expr": "ceph_pg_peering",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Peering",
+          "refId": "I"
+        },
+        {
+          "expr": "ceph_pg_degraded",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Degraded",
+          "refId": "B",
+          "step": 300
+        },
+        {
+          "expr": "ceph_pg_stale",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Stale",
+          "refId": "C",
+          "step": 300
+        },
+        {
+          "expr": "ceph_unclean_pgs",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Unclean",
+          "refId": "D",
+          "step": 300
+        },
+        {
+          "expr": "ceph_pg_undersized",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Undersized",
+          "refId": "E",
+          "step": 300
+        },
+        {
+          "expr": "ceph_pg_incomplete",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Incomplete",
+          "refId": "G"
+        },
+        {
+          "expr": "ceph_pg_forced_backfill",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Forced Backfill",
+          "refId": "H"
+        },
+        {
+          "expr": "ceph_pg_inconsistent",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Inconsistent",
+          "refId": "F"
+        },
+        {
+          "expr": "ceph_pg_forced_recovery",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Forced Recovery",
+          "refId": "J"
+        },
+        {
+          "expr": "ceph_pg_creating",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Creating",
+          "refId": "K"
+        },
+        {
+          "expr": "ceph_pg_wait_backfill",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Wait Backfill",
+          "refId": "L"
+        },
+        {
+          "expr": "ceph_pg_deep",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Deep",
+          "refId": "N"
+        },
+        {
+          "expr": "ceph_pg_scrubbing",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Scrubbing",
+          "refId": "O"
+        },
+        {
+          "expr": "ceph_pg_recovering",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Recovering",
+          "refId": "P"
+        },
+        {
+          "expr": "ceph_pg_repair",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Repair",
+          "refId": "Q"
+        },
+        {
+          "expr": "ceph_pg_down",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Down",
+          "refId": "R"
+        },
+        {
+          "expr": "ceph_pg_peered",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Peered",
+          "refId": "S"
+        },
+        {
+          "expr": "ceph_pg_backfill",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Backfill",
+          "refId": "T"
+        },
+        {
+          "expr": "ceph_pg_remapped",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Remapped",
+          "refId": "V"
+        },
+        {
+          "expr": "ceph_pg_backfill_toofull",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Backfill Toofull",
+          "refId": "W"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Bad PGs",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 1,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "grid": {},
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 51
+      },
+      "id": 20,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": true,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {},
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/^Total.*$/",
+          "stack": false
+        }
+      ],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "ceph_pg_degraded",
+          "format": "time_series",
+          "hide": false,
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Degraded",
+          "refId": "F",
+          "step": 300
+        },
+        {
+          "expr": "ceph_pg_stale",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Stale",
+          "refId": "A",
+          "step": 300
+        },
+        {
+          "expr": "ceph_pg_undersized",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "Undersized",
+          "refId": "B",
+          "step": 300
+        },
+        {
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "H"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Stuck PGs",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 1,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "collapsed": false,
+      "datasource": null,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
+      "id": 42,
+      "panels": [],
+      "repeat": null,
+      "title": "RECOVERY",
+      "type": "row"
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "editable": true,
+      "error": false,
+      "fill": 1,
+      "grid": {},
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
+      "id": 15,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {},
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "sum(irate(ceph_osd_recovery_ops[$interval]))",
+          "format": "time_series",
+          "interval": "$interval",
+          "intervalFactor": 1,
+          "legendFormat": "OPS",
+          "refId": "A",
+          "step": 300
+        },
+        {
+          "expr": "",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Operations",
+      "tooltip": {
+        "msResolution": false,
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": 0,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "auto": true,
+        "auto_count": 10,
+        "auto_min": "1m",
+        "current": {
+          "selected": false,
+          "text": "auto",
+          "value": "$__auto_interval_interval"
+        },
+        "datasource": null,
+        "hide": 0,
+        "includeAll": false,
+        "label": "Interval",
+        "multi": false,
+        "name": "interval",
+        "options": [
+          {
+            "selected": true,
+            "text": "auto",
+            "value": "$__auto_interval_interval"
+          },
+          {
+            "selected": false,
+            "text": "5s",
+            "value": "5s"
+          },
+          {
+            "selected": false,
+            "text": "10s",
+            "value": "10s"
+          },
+          {
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": false,
+            "text": "1m",
+            "value": "1m"
+          },
+          {
+            "selected": false,
+            "text": "10m",
+            "value": "10m"
+          },
+          {
+            "selected": false,
+            "text": "30m",
+            "value": "30m"
+          },
+          {
+            "selected": false,
+            "text": "1h",
+            "value": "1h"
+          },
+          {
+            "selected": false,
+            "text": "6h",
+            "value": "6h"
+          },
+          {
+            "selected": false,
+            "text": "12h",
+            "value": "12h"
+          },
+          {
+            "selected": false,
+            "text": "1d",
+            "value": "1d"
+          },
+          {
+            "selected": false,
+            "text": "7d",
+            "value": "7d"
+          },
+          {
+            "selected": false,
+            "text": "14d",
+            "value": "14d"
+          },
+          {
+            "selected": false,
+            "text": "30d",
+            "value": "30d"
+          }
+        ],
+        "query": "5s,10s,30s,1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+        "refresh": 2,
+        "skipUrlSync": false,
+        "type": "interval"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Ceph Cluster Overview",
+  "uid": "oVDYSH1Wz",
+  "version": 6
+}
+

--- a/grafana/dashboards/ceph/ceph_pools.json
+++ b/grafana/dashboards/ceph/ceph_pools.json
@@ -1,0 +1,752 @@
+
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 182,
+  "iteration": 1616693919192,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 4,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 1,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxPerRow": 2,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/.* read/",
+          "transform": "negative-Y"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk($topk,rate(ceph_pool_rd[5m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata) ",
+          "format": "time_series",
+          "hide": false,
+          "intervalFactor": 1,
+          "legendFormat": "{{name}} - read",
+          "refId": "F"
+        },
+        {
+          "expr": "topk($topk,rate(ceph_pool_wr[5m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata) ",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{name}} - write",
+          "refId": "A"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Top $topk Client IOPS by Pool",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "none",
+          "label": "Read (-) / Write (+)",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${DS_PROMETHEUS}",
+      "fill": 3,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 14,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "hiddenSeries": false,
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": true,
+        "current": true,
+        "max": true,
+        "min": false,
+        "show": true,
+        "sort": "max",
+        "sortDesc": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "maxPerRow": 2,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [
+        {
+          "alias": "/.* read/",
+          "transform": "negative-Y"
+        }
+      ],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "expr": "topk($topk,rate(ceph_pool_rd_bytes[5m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{name}} - read",
+          "refId": "A",
+          "textEditor": true
+        },
+        {
+          "expr": "topk($topk,rate(ceph_pool_wr_bytes[5m]) + on(pool_id) group_left(instance,name) ceph_pool_metadata)",
+          "format": "time_series",
+          "intervalFactor": 1,
+          "legendFormat": "{{name}} - write",
+          "refId": "B"
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Top $topk Client Throughput by Pool",
+      "tooltip": {
+        "shared": true,
+        "sort": 2,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "Bps",
+          "label": "Read (-) / Writes (+)",
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": false
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "columns": [
+        {
+          "text": "Current",
+          "value": "current"
+        }
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 0,
+        "y": 14
+      },
+      "id": 3,
+      "links": [],
+      "maxPerRow": 2,
+      "options": {},
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 5,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "Time",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "id",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "instance",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "job",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "Pool Name",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "name",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Pool ID",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "pool_id",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "IOPS (R+W)",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 0,
+          "pattern": "Value",
+          "thresholds": [],
+          "type": "number",
+          "unit": "none"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "topk($topk,((irate(ceph_pool_rd[5m]) + irate(ceph_pool_wr[5m])) + on(pool_id) group_left(instance,name) ceph_pool_metadata))",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 2,
+          "refId": "A",
+          "textEditor": true
+        }
+      ],
+      "title": "Top $topk Pools by Client IOPS",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "columns": [
+        {
+          "text": "Current",
+          "value": "current"
+        }
+      ],
+      "datasource": "${DS_PROMETHEUS}",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 8,
+        "y": 14
+      },
+      "id": 4,
+      "links": [],
+      "maxPerRow": 2,
+      "options": {},
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 5,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "align": "auto",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "hidden"
+        },
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "id",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "instance",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "job",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "Pool Name",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "name",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Pool ID",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "pool_id",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Throughput",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "Value",
+          "thresholds": [],
+          "type": "number",
+          "unit": "decbytes"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "topk($topk,(irate(ceph_pool_rd_bytes[5m]) + irate(ceph_pool_wr_bytes[5m])) + on(pool_id) group_left(instance,name) ceph_pool_metadata) ",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 2,
+          "refId": "A",
+          "textEditor": true
+        }
+      ],
+      "title": "Top $topk Pools by Throughput",
+      "transform": "table",
+      "type": "table"
+    },
+    {
+      "columns": [],
+      "datasource": "${DS_PROMETHEUS}",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 7,
+        "w": 8,
+        "x": 16,
+        "y": 14
+      },
+      "id": 5,
+      "links": [],
+      "maxPerRow": 3,
+      "options": {},
+      "pageSize": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 5,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "Time",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "instance",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "job",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        },
+        {
+          "alias": "Pool Name",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "name",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "Pool ID",
+          "align": "auto",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "pool_id",
+          "thresholds": [],
+          "type": "number",
+          "unit": "short"
+        },
+        {
+          "alias": "Capacity Used",
+          "align": "auto",
+          "colorMode": "value",
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "pattern": "Value",
+          "thresholds": [
+            "70",
+            "85"
+          ],
+          "type": "number",
+          "unit": "percentunit"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "topk(1,((ceph_pool_stored / (ceph_pool_stored + ceph_pool_max_avail)) * on(pool_id) group_left(name) ceph_pool_metadata))",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "",
+          "refId": "D"
+        }
+      ],
+      "title": "Top $topk Pools By Capacity Used",
+      "transform": "table",
+      "type": "table"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 22,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 0,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "datasource",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "text": "15",
+          "value": "15"
+        },
+        "hide": 0,
+        "label": "Top K",
+        "name": "topk",
+        "options": [
+          {
+            "text": "15",
+            "value": "15"
+          }
+        ],
+        "query": "15",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "15s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "browser",
+  "title": "Ceph Pools Overview",
+  "uid": "z99hzWtmk",
+  "version": 3
+}
+

--- a/prometheus/ceph.rules
+++ b/prometheus/ceph.rules
@@ -342,19 +342,19 @@ groups:
 - name: Ceph Latency
   rules:
     - alert: CephHighLatency
-    expr: irate(ceph_osd_op_r_latency_sum[5m]) >= 15
-    for: 2m
-    labels:
-      severity: warning
-    annotations:
-      description: "OSD read latencies {{ $labels.ceph_daemon }} > 15ms. It must be checked which host the OSD is on."
-      message: "Ceph OSD high read latency ({{ $labels.ceph_daemon }})"
+      expr: irate(ceph_osd_op_r_latency_sum[5m]) >= 15
+      for: 2m
+      labels:
+        severity: warning
+      annotations:
+        description: "OSD read latencies {{ $labels.ceph_daemon }} > 15ms. It must be checked which host the OSD is on."
+        message: "Ceph OSD high read latency ({{ $labels.ceph_daemon }})"
 
-  - alert: CephHighLatency_crit
-    expr: irate(ceph_osd_op_r_latency_sum[5m]) >= 25
-    for: 2m
-    labels:
-      severity: critical
-    annotations:
-      description: "OSD read latencies {{ $labels.ceph_daemon }} > 25ms. It must be checked which host the OSD is on."
-      message: "Ceph OSD high read latency ({{ $labels.ceph_daemon }})"
+    - alert: CephHighLatency_crit
+      expr: irate(ceph_osd_op_r_latency_sum[5m]) >= 25
+      for: 2m
+      labels:
+        severity: critical
+      annotations:
+        description: "OSD read latencies {{ $labels.ceph_daemon }} > 25ms. It must be checked which host the OSD is on."
+        message: "Ceph OSD high read latency ({{ $labels.ceph_daemon }})"

--- a/prometheus/ceph.rules
+++ b/prometheus/ceph.rules
@@ -338,3 +338,23 @@ groups:
         description: >
           the Ceph-Manager-Exporter is down.
           message: CEPH target down for more than 1m, please check
+
+- name: Ceph Latency
+  rules:
+    - alert: CephHighLatency
+    expr: irate(ceph_osd_op_r_latency_sum[5m]) >= 15
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      description: "OSD read latencies {{ $labels.ceph_daemon }} > 15ms. It must be checked which host the OSD is on."
+      message: "Ceph OSD high read latency ({{ $labels.ceph_daemon }})"
+
+  - alert: CephHighLatency_crit
+    expr: irate(ceph_osd_op_r_latency_sum[5m]) >= 25
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      description: "OSD read latencies {{ $labels.ceph_daemon }} > 25ms. It must be checked which host the OSD is on."
+      message: "Ceph OSD high read latency ({{ $labels.ceph_daemon }})"

--- a/prometheus/container.rules
+++ b/prometheus/container.rules
@@ -1,0 +1,60 @@
+groups:
+- name: container.rules
+  rules:
+  
+  - alert: ContainerKilled
+    expr: time() - container_last_seen{name!=""} > 60
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: "The container {{ $labels.name }} on host {{ $labels.host_name }} is no longer running."
+      message: "Container {{ $labels.name }} killed on Host {{ $labels.host_name }}"
+  
+  - alert: ContainerCpuUsage
+    expr: (sum(rate(container_cpu_usage_seconds_total{name!=""}[3m])) BY (instance,
+      name) * 100) > 95
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "The container is using too many CPU resources. Since the containers are unlimited, it must be checked whether this behavior increases."
+      message: "Container CPU usage {{ $labels.name }} on Host {{ $labels.host_name }}"
+  
+  - alert: ContainerMemoryUsage
+    expr: (sum(container_memory_working_set_bytes{name!=""}) BY (instance, name) /
+      sum(container_spec_memory_limit_bytes > 0) BY (instance, name) * 100) > 90
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "The container is using too many RAM resources. Since the containers are unlimited, it must be checked whether this behavior increases."
+      message: "Container Memory usage {{ $labels.name }} on Host {{ $labels.host_name }}"
+  
+  - alert: ContainerVolumeUsage
+    expr: (1 - (sum(container_fs_inodes_free{name!=""}) BY (instance) / sum(container_fs_inodes_total)
+      BY (instance)) * 100) > 95
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      description: "The disk of the container {{ $labels.name }} on host {{ $labels.host_name }} is full. The container volume is usually a local directory on the host."
+      message: "Container Volume usage {{ $labels.name }} on Host {{ $labels.host_name }}"
+  
+  - alert: ContainerVolumeIoUsage
+    expr: (sum(container_fs_io_current{name!=""}) BY (instance, name) * 100) > 90
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      description: "Container {{ $labels.name }} on host {{ $labels.host_name }} generates too much IO. The container volume is usually a local directory on the host."
+      message: "Container Volume IO usage {{ $labels.name }} on Host {{ $labels.host_name }}"
+  
+  - alert: ContainerHighThrottleRate
+    expr: rate(container_cpu_cfs_throttled_seconds_total{name!=""}[3m]) > 1
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      description: "Since we use unlimited containers this shouldn't happen. If this occurs repeatedly, the container or the process running within it must be analyzed in more detail."
+      message: "Container high throttle rate {{ $labels.name }} on Host {{ $labels.host_name }}"

--- a/prometheus/fluentd-aggregator.rules
+++ b/prometheus/fluentd-aggregator.rules
@@ -1,0 +1,25 @@
+groups:
+- name: fluentd-aggregator.rules
+  rules:
+
+  - alert: fluentd_aggregator_buffer_size_warn
+    expr: fluentd_output_status_buffer_total_bytes > 5.24288e+08
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      description: "Most probably fluentd-aggragator on {{ $labels.host_name }}
+        is unable to forward data. Event flooding is also possible
+        after restarts/changes in the Openstack environment"
+      message: "Buffer of fluentd-aggregator is filling up. {{ $labels.host_name }}"
+
+  - alert: fluentd_aggregator_buffer_size_crit
+    expr: fluentd_output_status_buffer_total_bytes > 2.097152e+09
+    for: 15m
+    labels:
+      severity: critical
+    annotations:
+      description: "Most probably fluentd-aggragator on {{ $labels.host_name }}
+        is unable to forward data. Event flooding is also possible
+        after restarts/changes in the Openstack environment"
+      message: "Buffer of fluentd-aggregator is filling up. {{ $labels.host_name }}"

--- a/prometheus/haproxy.rules
+++ b/prometheus/haproxy.rules
@@ -5,7 +5,6 @@
 groups:
 - name: HAProxy
   rules:
-
     - alert: HaproxyDown
       expr: haproxy_up == 0
       for: 1m
@@ -41,6 +40,7 @@ groups:
         severity: critical
       annotations:
         description: "HAProxy server response errors ({{ $labels.backend }} on instance {{ $labels.server }})"
+        description: "HAProxy server response errors ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyServerConnectionErrors
       expr: sum(rate(haproxy_server_connection_errors_total[1m])) BY (server) > 100
@@ -48,6 +48,7 @@ groups:
       labels:
         severity: critical
       annotations:
+        description: "HAProxy server connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
         description: "HAProxy server connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyBackendMaxActiveSession
@@ -58,6 +59,7 @@ groups:
         severity: warning
       annotations:
         description: "HAProxy backend max active session ({{ $labels.backend }} on instance {{ $labels.server }})"
+        description: "HAProxy backend max active session ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyHttpSlowingDown
       expr: avg(haproxy_backend_http_total_time_average_seconds) BY (haproxy_backend_sessions_total) > 7
@@ -65,6 +67,7 @@ groups:
       labels:
         severity: warning
       annotations:
+        description: "HAProxy HTTP slowing down ({{ $labels.backend }} on instance {{ $labels.server }})"
         description: "HAProxy HTTP slowing down ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyServerHealthcheckFailure
@@ -76,19 +79,19 @@ groups:
         description: "HAProxy server healthcheck failure ({{ $labels.server }} for backend {{ $labels.backend }})"
 
     - alert: HaproxyBackendConnectionErrors
-    expr: sum(rate(haproxy_backend_connection_errors_total[1m])) BY (haproxy_backend_sessions_total) > 100
-    for: 1m
-    labels:
-      severity: critical
-    annotations:
-      description: "Too many connection errors to the {{ $labels.backend }} backend (> 100 req/s). Overload due to high number of requests"
-      message: "HAProxy backend connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
+      expr: sum(rate(haproxy_backend_connection_errors_total[1m])) BY (haproxy_backend_sessions_total) > 100
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        description: "Too many connection errors to the {{ $labels.backend }} backend (> 100 req/s). Overload due to high number of requests"
+        message: "HAProxy backend connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
     
     - alert: HaproxyCephDashboardDown
-    expr: sum(haproxy_server_up{backend="ceph_dashboard"}) == 0
-    for: 1m
-    labels:
-      severity: warning
-    annotations:
-      description: "HAProxy {{ $labels.backend }} is down."
-      message: "HAProxy {{ $labels.backend }} auf {{ $labels.server }}"
+      expr: sum(haproxy_server_up{backend="ceph_dashboard"}) == 0
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        description: "HAProxy {{ $labels.backend }} is down."
+        message: "HAProxy {{ $labels.backend }} auf {{ $labels.server }}"

--- a/prometheus/haproxy.rules
+++ b/prometheus/haproxy.rules
@@ -87,14 +87,7 @@ groups:
       annotations:
         description: "Too many connection errors to the {{ $labels.backend }} backend (> 100 req/s). Overload due to high number of requests"
         message: "HAProxy backend connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
-      expr: sum(rate(haproxy_backend_connection_errors_total[1m])) BY (haproxy_backend_sessions_total) > 100
-      for: 1m
-      labels:
-        severity: critical
-      annotations:
-        description: "Too many connection errors to the {{ $labels.backend }} backend (> 100 req/s). Overload due to high number of requests"
-        message: "HAProxy backend connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
-    
+
     - alert: HaproxyCephDashboardDown
       expr: sum(haproxy_server_up{backend="ceph_dashboard"}) == 0
       for: 1m

--- a/prometheus/haproxy.rules
+++ b/prometheus/haproxy.rules
@@ -40,7 +40,7 @@ groups:
       labels:
         severity: critical
       annotations:
-        description: HAProxy server response errors ({{ $labels.backend }} on instance {{ $labels.server }})
+        description: "HAProxy server response errors ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyServerConnectionErrors
       expr: sum(rate(haproxy_server_connection_errors_total[1m])) BY (server) > 100
@@ -48,7 +48,7 @@ groups:
       labels:
         severity: critical
       annotations:
-        description: HAProxy server connection errors ({{ $labels.backend }} on instance {{ $labels.server }})
+        description: "HAProxy server connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyBackendMaxActiveSession
       expr: ((sum(avg_over_time(haproxy_backend_max_sessions[2m])) BY (haproxy_backend_sessions_total) / sum(avg_over_time(haproxy_backend_limit_sessions[2m])) BY (haproxy_backend_sessions_total))
@@ -57,7 +57,7 @@ groups:
       labels:
         severity: warning
       annotations:
-        description: HAProxy backend max active session ({{ $labels.backend }} on instance {{ $labels.server }})
+        description: "HAProxy backend max active session ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyHttpSlowingDown
       expr: avg(haproxy_backend_http_total_time_average_seconds) BY (haproxy_backend_sessions_total) > 7
@@ -65,7 +65,7 @@ groups:
       labels:
         severity: warning
       annotations:
-        description: HAProxy HTTP slowing down ({{ $labels.backend }} on instance {{ $labels.server }})
+        description: "HAProxy HTTP slowing down ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyServerHealthcheckFailure
       expr: increase(haproxy_server_check_failures_total[5m]) > 3
@@ -73,4 +73,22 @@ groups:
       labels:
         severity: warning
       annotations:
-        description: HAProxy server healthcheck failure ({{ $labels.server }} for backend {{ $labels.backend }})
+        description: "HAProxy server healthcheck failure ({{ $labels.server }} for backend {{ $labels.backend }})"
+
+    - alert: HaproxyBackendConnectionErrors
+    expr: sum(rate(haproxy_backend_connection_errors_total[1m])) BY (haproxy_backend_sessions_total) > 100
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      description: "Too many connection errors to the {{ $labels.backend }} backend (> 100 req/s). Overload due to high number of requests"
+      message: "HAProxy backend connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
+    
+    - alert: HaproxyCephDashboardDown
+    expr: sum(haproxy_server_up{backend="ceph_dashboard"}) == 0
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      description: "HAProxy {{ $labels.backend }} is down."
+      message: "HAProxy {{ $labels.backend }} auf {{ $labels.server }}"

--- a/prometheus/haproxy.rules
+++ b/prometheus/haproxy.rules
@@ -40,7 +40,7 @@ groups:
         severity: critical
       annotations:
         description: "HAProxy server response errors ({{ $labels.backend }} on instance {{ $labels.server }})"
-        description: "HAProxy server response errors ({{ $labels.backend }} on instance {{ $labels.server }})"
+        message: "HAProxy server response errors ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyServerConnectionErrors
       expr: sum(rate(haproxy_server_connection_errors_total[1m])) BY (server) > 100
@@ -49,7 +49,7 @@ groups:
         severity: critical
       annotations:
         description: "HAProxy server connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
-        description: "HAProxy server connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
+        message: "HAProxy server connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyBackendMaxActiveSession
       expr: ((sum(avg_over_time(haproxy_backend_max_sessions[2m])) BY (haproxy_backend_sessions_total) / sum(avg_over_time(haproxy_backend_limit_sessions[2m])) BY (haproxy_backend_sessions_total))
@@ -59,7 +59,7 @@ groups:
         severity: warning
       annotations:
         description: "HAProxy backend max active session ({{ $labels.backend }} on instance {{ $labels.server }})"
-        description: "HAProxy backend max active session ({{ $labels.backend }} on instance {{ $labels.server }})"
+        message: "HAProxy backend max active session ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyHttpSlowingDown
       expr: avg(haproxy_backend_http_total_time_average_seconds) BY (haproxy_backend_sessions_total) > 7
@@ -68,7 +68,7 @@ groups:
         severity: warning
       annotations:
         description: "HAProxy HTTP slowing down ({{ $labels.backend }} on instance {{ $labels.server }})"
-        description: "HAProxy HTTP slowing down ({{ $labels.backend }} on instance {{ $labels.server }})"
+        message: "HAProxy HTTP slowing down ({{ $labels.backend }} on instance {{ $labels.server }})"
 
     - alert: HaproxyServerHealthcheckFailure
       expr: increase(haproxy_server_check_failures_total[5m]) > 3
@@ -77,8 +77,16 @@ groups:
         severity: warning
       annotations:
         description: "HAProxy server healthcheck failure ({{ $labels.server }} for backend {{ $labels.backend }})"
-
+        message: "HAProxy server healthcheck failure ({{ $labels.server }} for backend {{ $labels.backend }})"
+        
     - alert: HaproxyBackendConnectionErrors
+      expr: sum(rate(haproxy_backend_connection_errors_total[1m])) BY (haproxy_backend_sessions_total) > 100
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        description: "Too many connection errors to the {{ $labels.backend }} backend (> 100 req/s). Overload due to high number of requests"
+        message: "HAProxy backend connection errors ({{ $labels.backend }} on instance {{ $labels.server }})"
       expr: sum(rate(haproxy_backend_connection_errors_total[1m])) BY (haproxy_backend_sessions_total) > 100
       for: 1m
       labels:
@@ -94,4 +102,4 @@ groups:
         severity: warning
       annotations:
         description: "HAProxy {{ $labels.backend }} is down."
-        message: "HAProxy {{ $labels.backend }} auf {{ $labels.server }}"
+        message: "HAProxy {{ $labels.backend }} on {{ $labels.server }}"

--- a/prometheus/hardware.rules
+++ b/prometheus/hardware.rules
@@ -1,0 +1,263 @@
+groups:
+- name: hardware.rules
+  rules:
+  
+  - alert: node_network_bond_slaves_down
+    expr: node_bonding_slaves - node_bonding_active > 0
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: "On {{ $labels.host_name }} in Bond {{ $labels.master }} is {{ $value }} interface(s) down."
+      message: "Host {{ $labels.host_name }}: {{ $labels.master }}  missing {{ $value }} slave interface(s)"
+  
+  - alert: HostOutOfMemory
+    expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      description: "The host {{ $labels.host_name }} was at 90% memory capacity for at least an hour."
+      message: "{{ $labels.host_name }} out of memory. Please check"
+  
+  - alert: HostOutOfMemory
+    expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      description: "The host {{ $labels.host_name }} was at 90% memory capacity for at least an hour."
+      message: "{{ $labels.host_name }} out of memory. Please check"
+  
+  - alert: ClusterOutOfMemory
+    expr: sum(node_memory_MemAvailable_bytes) / sum(node_memory_MemTotal_bytes) * 100 < 5
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      description: "The cluster's memory was 95% full for at least an hour."
+      message: "Cluster out of memory. Please check"
+  
+  - alert: HostMemoryUnderMemoryPressure
+    expr: rate(node_vmstat_pgmajfault[1m]) > 1000
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      message: "{{ $labels.host_name }} memory under memory pressure"
+  
+  - alert: HostUnusualDiskReadRate
+    expr: sum(rate(node_disk_read_bytes_total[2m])) BY (instance,host_name,device) / 1024 / 1024 > 500
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      description: "The device {{ $labels.device }} of the host {{ $labels.host_name }} has a high read rate (more than 50 MB/s) over five minutes."
+      message: "{{ $labels.host_name }} unusual disk read rate on {{ $labels.device }})"
+  
+  - alert: HostUnusualDiskWriteRate
+    expr: sum(rate(node_disk_written_bytes_total[2m])) BY (instance,host_name,device) / 1024 / 1024 > 500
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      description: "The device {{ $labels.device }} of the host {{ $labels.host_name }} has a high write rate (more than 50 MB/s) over five minutes."
+      message: "{{ $labels.host_name }} unusual disk write rate on {{ $labels.device }}"
+  
+  - alert: HostOutOfDiskSpace
+    expr: (node_filesystem_avail_bytes{fstype="ext4"} * 100) / node_filesystem_size_bytes{fstype="ext4"} < 10 and ON(instance, device, mountpoint) node_filesystem_readonly == 0
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      description: "The device {{ $labels.mountpoint }} on host {{ $labels.host_name }} has <10% disk space"
+      message: "{{ $labels.host_name }} out of disk space on {{ $labels.mountpoint }}"
+  
+  - alert: HostDiskWillFillIn24Hours
+    expr: (node_filesystem_avail_bytes{fstype="ext4"} * 100) / node_filesystem_size_bytes{fstype="ext4"} < 10 and ON(instance, device, mountpoint) predict_linear(node_filesystem_avail_bytes{fstype!~"tmpfs"}[1h], 24 * 3600) < 0 and ON(instance, device, mountpoint) node_filesystem_readonly == 0
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      description: "The disk {{ $labels.mountpoint }} of the host {{ $labels.host_name }} will fill up in the next 24 hours if writing continues at the current write rate."
+      message: "{{ $labels.host_name }} disk will fill in 24 hours on {{ $labels.mountpoint }}"
+  
+  - alert: HostOutOfInodes
+    expr: node_filesystem_files_free{mountpoint="/"} / node_filesystem_files{mountpoint="/"} * 100 < 10 and ON(instance, device, mountpoint) node_filesystem_readonly{mountpoint="/"} == 0
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      description: "The disk {{ $labels.mountpoint }} on {{ $labels.host_name }} has less than 10% inodes free."
+      message: "{{ $labels.host_name }} out of inodes on {{ $labels.mountpoint }}"
+  
+  - alert: HostInodesWillFillIn24Hours
+    expr: node_filesystem_files_free{mountpoint="/"} / node_filesystem_files{mountpoint="/"} * 100 < 10 and predict_linear(node_filesystem_files_free{mountpoint="/"}[1h], 24 * 3600) < 0 and ON(instance, device, mountpoint) node_filesystem_readonly{mountpoint="/"} == 0
+    for: 2m
+    labels:
+      severity: warning
+    annotations:
+      description: "The inodes of the disk {{ $labels.mountpoint }} on {{ $labels.host_name }} will fill up in the next 24 hours if writing continues at the current write rate."
+      message: "{{ $labels.host_name }} inodes will fill in 24 hours on {{ $labels.mountpoint }}"
+  
+  - alert: HostUnusualDiskReadLatency
+    expr: rate(node_disk_read_time_seconds_total[1m]) / rate(node_disk_reads_completed_total[1m]) > 0.1 and rate(node_disk_reads_completed_total[1m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "The read latency of the disk {{ $labels.mountpoint }} on {{ $labels.host_name }} has been >100ms for over two minutes."
+      message: "{{ $labels.host_name }} unusual disk read latency on {{ $labels.device }}"
+  
+  - alert: HostUnusualDiskWriteLatency
+    expr: rate(node_disk_write_time_seconds_total[1m]) / rate(node_disk_writes_completed_total[1m]) > 0.1 and rate(node_disk_writes_completed_total[1m]) > 0
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "The write latency of the disk {{ $labels.mountpoint }} on {{ $labels.host_name }} has been >100ms for over two minutes."
+      message: "{{ $labels.host_name }} unusual disk write latency on {{ $labels.device }}"
+  
+  - alert: HostHighCpuLoad
+    expr: 100 - (avg(rate(node_cpu_seconds_total{mode="idle"}[2m])) BY (instance) * 100) > 95
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      description: "The CPU load of {{ $labels.host_name }} is > 95%."
+      message: "{{ $labels.host_name }} high CPU load"
+  
+  - alert: HostCpuStealNoisyNeighbor
+    expr: avg(rate(node_cpu_seconds_total{mode="steal"}[5m])) BY (instance) * 100 > 10
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "CPU steal from {{ $labels.host_name }} is > 10%. The VMs fight over CPU time."
+      message: "{{ $labels.host_name }} CPU steal noisy neighbor"
+  
+  - alert: HostSwapIsFillingUp
+    expr: (1 - (node_memory_SwapFree_bytes / node_memory_SwapTotal_bytes)) * 100 > 80
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "Swap of {{ $labels.host_name }} is > 80%."
+      message: "{{ $labels.host_name }} swap is filling up"
+  
+  - alert: HostPhysicalComponentTooHot
+    expr: node_hwmon_temp_celsius > 87
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      description: "Certain server components on {{ $labels.host_name }} have a temperature of over 87°"
+      message: "{{ $labels.host_name }} physical component too hot"
+  
+  - alert: HostNodeOvertemperatureAlarm
+    expr: node_hwmon_temp_crit_alarm_celsius == 1
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      description: "Temperature alarm triggered on {{ $labels.host_name }}. It is possible that the host will shut down in the near future."
+      message: "{{ $labels.host_name }} node overtemperature alarm"
+  
+  - alert: HostRaidArrayGotInactive
+    expr: node_md_is_active != 1
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      description: "The RAID array {{ $labels.device }} on {{ $labels.host_name }} is degraded due to an SSD failure. The defective SSD must be replaced to bring the RAID back to the desired state. VALUE = {{ $value }} LABELS: {{ $labels }}"
+      message: "{{ $labels.host_name }} RAID array got inactive"
+  
+  - alert: HostRaidDiskFailure
+    expr: node_md_disks_active < 2
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      description: "One of the two disks relevant to the operating system of the {{ $labels.device }} RAID1 on {{ $labels.host_name }} are defective."
+      message: "{{ $labels.host_name }} RAID disk failure Array {{ $labels.device }}"
+  
+  - alert: HostKernelVersionDeviations
+    expr: count(sum(label_replace(node_uname_info, "kernel", "$1", "release", "([0-9]+.[0-9]+.[0-9]+).*")) BY (kernel)) > 1
+    for: 6h
+    labels:
+      severity: warning
+    annotations:
+      description: "The kernel version of {{ $labels.nodename }} is at a different level."
+      message: "Host kernel version deviations on Host {{ $labels.nodename }}"
+  
+  - alert: HostOomKillDetected
+    expr: increase(node_vmstat_oom_kill[1m]) > 0
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      description: "The OOM killer killed processes on {{ $labels.host_name }}."
+      message: "{{ $labels.host_name }} OOM kill detected"
+  
+  - alert: HostEdacCorrectableErrorsDetected
+    expr: increase(node_edac_correctable_errors_total[1m]) > 0
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      description: "{{ $labels.host_name }} detected {{ $value }} recoverable memory errors through Automatic Error Detection and Correction (EDAC)."
+      message: "{{ $labels.host_name }} EDAC Correctable Errors detected (instance )"
+  
+  - alert: HostNetworkReceiveErrors
+    expr: rate(node_network_receive_errs_total[2m]) / rate(node_network_receive_packets_total[2m]) > 0.01
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      description: "{{ $labels.host_name }} interface {{ $labels.device }} has registered {{ $value }} errors on incoming packets in the last 10 minutes."
+      message: "{{ $labels.host_name }} Network Receive Errors on interface {{ $labels.device }})"
+  
+  - alert: HostNetworkTransmitErrors
+    expr: rate(node_network_transmit_errs_total[2m]) / rate(node_network_transmit_packets_total[2m]) > 0.01
+    for: 10m
+    labels:
+      severity: critical
+    annotations:
+      description: "{{ $labels.host_name }} interface {{ $labels.device }} has registered {{ $value }} errors in packages sent in the last 10 minutes."
+      message: "{{ $labels.host_name }} Network Transmit Errors on interface {{ $labels.device }}"
+  
+  - alert: HostNetworkInterfaceSaturated
+    expr: (rate(node_network_receive_bytes_total{device!~"^tap.*"}[1m]) + rate(node_network_transmit_bytes_total{device!~"^tap.*"}[1m])) / node_network_speed_bytes{device!~"^tap.*"} > 0.8
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      description: "{{ $labels.device }} The node {{ $labels.host_name }} is saturated and is over 80% utilization "
+      message: "{{ $labels.host_name }} Network Interface {{ $labels.device }} Saturated"
+  
+  - alert: HostConntrackLimit
+    expr: node_nf_conntrack_entries / node_nf_conntrack_entries_limit > 0.8
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      description: "{{ $labels.host_name }} The node's connection tracking limit has almost been reached in the last five minutes. "
+      message: "{{ $labels.host_name }} conntrack limit reached"
+  
+  - alert: HostClockSkew
+    expr: (node_timex_offset_seconds > 0.05 and deriv(node_timex_offset_seconds[5m]) >= 0) or (node_timex_offset_seconds < -0.05 and deriv(node_timex_offset_seconds[5m]) <= 0)
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      description: "Time deviation registered. The system clock is no longer synchronous. VALUE = {{ $value }} LABELS: {{ $labels }}"
+      message: "Host clock skew (instance {{ $labels.host_name }})"
+  
+  - alert: HostClockNotSynchronising
+    expr: min_over_time(node_timex_sync_status[1m]) == 0 and node_timex_maxerror_seconds >= 16
+    for: 2m
+    labels:
+      severity: critical
+    annotations:
+      description: "The time synchronization of the host {{ $labels.host_name }} is not correct"
+      message: "{{ $labels.host_name }} clock not synchronising"

--- a/prometheus/hardware.rules
+++ b/prometheus/hardware.rules
@@ -1,7 +1,6 @@
 groups:
 - name: hardware.rules
   rules:
-  
   - alert: node_network_bond_slaves_down
     expr: node_bonding_slaves - node_bonding_active > 0
     for: 5m
@@ -10,15 +9,6 @@ groups:
     annotations:
       description: "On {{ $labels.host_name }} in Bond {{ $labels.master }} is {{ $value }} interface(s) down."
       message: "Host {{ $labels.host_name }}: {{ $labels.master }}  missing {{ $value }} slave interface(s)"
-  
-  - alert: HostOutOfMemory
-    expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10
-    for: 1h
-    labels:
-      severity: warning
-    annotations:
-      description: "The host {{ $labels.host_name }} was at 90% memory capacity for at least an hour."
-      message: "{{ $labels.host_name }} out of memory. Please check"
   
   - alert: HostOutOfMemory
     expr: node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes * 100 < 10

--- a/prometheus/mysql.rules
+++ b/prometheus/mysql.rules
@@ -84,6 +84,49 @@ groups:
     labels:
       severity: warning
     annotations:
-      description: MySQL innodb replication is lagging on host {{ $labels.host_name }}
+      description: "MySQL innodb replication is lagging on host {{ $labels.host_name }}"
 
+  - alert: MysqlInnodbLogWaits
+    expr: rate(mysql_global_status_innodb_log_waits[15m]) > 10
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      description: "Writing the InnoDB logs is too slow on {{ $labels.host_name }}."
+      message: "MySQL InnoDB log waits on Host {{ $labels.host_name }}"
 
+  - alert: mariadb_table_lock_wait_high
+    expr: 100 * mysql_global_status_table_locks_waited / (mysql_global_status_table_locks_waited + mysql_global_status_table_locks_immediate) > 30
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "Mariadb hat hohe Table Lock Waits."
+      message: "Mariadb table lock waits are high on host {{ $labels.host_name }}"
+
+  - alert: mariadb_node_not_ready
+    expr: mysql_global_status_wsrep_ready != 1
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "{{$labels.job}} is not ready on host {{ $labels.host_name }}."
+      message: "Galera cluster node not ready on host {{ $labels.host_name }}"
+
+  - alert: mariadb_galera_node_out_of_sync
+    expr: mysql_global_status_wsrep_local_state != 4 and mysql_global_variables_wsrep_desync == 0
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "{{$labels.job}} on {{$labels.instance}} ist out of sync."
+      message: "Galera cluster node out of sync on host {{ $labels.host_name }}"
+
+  - alert: mariadb_innodb_replication_fallen_behind
+    expr: (mysql_global_variables_innodb_replication_delay > 30) and ON(instance) (predict_linear(mysql_global_variables_innodb_replication_delay[5m], 60 * 2) > 0)
+    for: 10m
+    labels:
+      severity: warning
+    annotations:
+      description: "MySQL InnoDB replication is running too slow on host {{ $labels.host_name }} and hasn't gotten faster for 10 minutes."
+      message: "MySQL innodb replication is lagging on host {{ $labels.host_name }}"

--- a/prometheus/mysql.rules
+++ b/prometheus/mysql.rules
@@ -121,12 +121,3 @@ groups:
     annotations:
       description: "{{$labels.job}} on {{$labels.instance}} ist out of sync."
       message: "Galera cluster node out of sync on host {{ $labels.host_name }}"
-
-  - alert: mariadb_innodb_replication_fallen_behind
-    expr: (mysql_global_variables_innodb_replication_delay > 30) and ON(instance) (predict_linear(mysql_global_variables_innodb_replication_delay[5m], 60 * 2) > 0)
-    for: 10m
-    labels:
-      severity: warning
-    annotations:
-      description: "MySQL InnoDB replication is running too slow on host {{ $labels.host_name }} and hasn't gotten faster for 10 minutes."
-      message: "MySQL innodb replication is lagging on host {{ $labels.host_name }}"

--- a/prometheus/openstack.rules
+++ b/prometheus/openstack.rules
@@ -3,13 +3,264 @@
 groups:
 - name: OpenStack
   rules:
+  
   - alert: OpenStackServiceDown
     expr: (sum({__name__=~"openstack.+_state", job="openstack_exporter"} == 0) by (hostname, service))
     for: 1m
     labels:
       severity: alert
     annotations:
-      summary: "{{ $labels.service }} at {{ $labels.instance }} is down"
+      message: "{{ $labels.service }} at {{ $labels.instance }} is down"
       description: "OpenStack service {{ $labels.service }} at {{ $labels.instance }} is down"
+  
+  - alert: os_nova_per_cluster_memory_usage
+    expr: sum(openstack_placement_resource_usage{hostname=~'compute.*', resourcetype='MEMORY_MB'}) / sum(openstack_placement_resource_total{hostname=~'compute.*', resourcetype='MEMORY_MB'})  * 100 > 60
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      description: "More than 60% RAM is used in the cluster"
+      message: "More than 60 Percent RAM usage"
+  
+  - alert: os_nova_per_cluster_memory_usage_crit
+    expr: sum(openstack_placement_resource_usage{hostname=~'compute.*', resourcetype='MEMORY_MB'}) / sum(openstack_placement_resource_total{hostname=~'compute.*', resourcetype='MEMORY_MB'})  * 100 > 80
+    for: 1h
+    labels:
+      severity: critical
+    annotations:
+      description: "More than 80% RAM is used in the cluster"
+      message: "More than 80 Percent RAM usage"
+  
+  - alert: os_nova_per_host_vcpu_limit
+    expr: openstack_placement_resource_total{hostname=~'compute.*', resourcetype='VCPU'} * 3 - openstack_placement_resource_usage{hostname=~'compute.*', resourcetype='VCPU'} < 30
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      description: "Less then 30 VCPUs left on {{ $labels.hostname }}"
+      message: "Less then 30 VCPUs left on {{ $labels.hostname }}"
+  
+  - alert: os_nova_per_cluster_vcpu_limit
+    expr: sum(openstack_placement_resource_total{hostname=~'compute.*', resourcetype='VCPU'}) * (avg(openstack_placement_resource_allocation_ratio{hostname=~'compute.*', resourcetype='VCPU'})) - sum(openstack_placement_resource_usage{hostname=~'compute.*', resourcetype='VCPU'}) < 512
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      description: "Less then 512 VCPUs left in the Cluster"
+      message: "Less then 512 VCPUs left in the Cluster"
+  
+  - alert: os_nova_per_cluster_vcpu_usage
+    expr: sum(openstack_placement_resource_usage{hostname=~'compute.*', resourcetype='VCPU'}) / (sum(openstack_placement_resource_total{hostname=~'compute.*', resourcetype='VCPU'}) * (avg(openstack_placement_resource_allocation_ratio{hostname=~'compute.*', resourcetype='VCPU'}))) * 100 > 60
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      description: 'More than 60 Percent vCPU usage'
+      message: "More than 60 Percent vCPU usage"
+  
+  - alert: os_nova_per_cluster_vcpu_usage_crit
+    expr: sum(openstack_placement_resource_usage{hostname=~'compute.*', resourcetype='VCPU'}) / (sum(openstack_placement_resource_total{hostname=~'compute.*', resourcetype='VCPU'}) * (avg(openstack_placement_resource_allocation_ratio{hostname=~'compute.*', resourcetype='VCPU'}))) * 100 > 80
+    for: 1h
+    labels:
+      severity: critical
+    annotations:
+      description: 'More than 80 Percent vCPU usage'
+      message: "More than 80 Percent vCPU usage"
+  
+  - alert: os_nova_per_host_vcpu_limit_crit
+    expr: openstack_placement_resource_total{hostname=~'compute.*', resourcetype='VCPU'} * 3 - openstack_placement_resource_usage{hostname=~'compute.*', resourcetype='VCPU'} < 5
+    for: 15m
+    labels:
+      severity: critical
+    annotations:
+      description: 'Less then 5 VCPUs left on {{ $labels.hostname }}'
+      message: "Less then 5 VCPUs left on {{ $labels.hostname }}"
+  
+  - alert: os_glance_api_availability
+    expr: openstack_glance_up != 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: 'The Glance API is unavailable for over five minutes. This means customers cannot create additional instances.'
+      message: "Glance API is not available"
+  
+  - alert: os_nova_api_availability
+    expr: openstack_nova_up != 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: 'The Nova API is unavailable for over five minutes. This means customers cannot create additional instances.'
+      message: "Nova API is not available"
+  
+  - alert: os_keystone_api_availability
+    expr: openstack_identity_up != 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: 'The Keystone API is unavailable for over five minutes. This means customers cannot create additional instances.'
+      message: "Keystone API is not available"
+  
+  - alert: os_neutron_api_availability
+    expr: openstack_neutron_up != 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: 'The Neutron API is unavailable for over five minutes. This means customers can no longer reserve IP addresses or set firewall rules.'
+      message: "Neutron API is not available"
+  
+  - alert: os_designate_api_availability
+    expr: openstack_designate_up != 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: 'The Designate API is unavailable for over five minutes. This means that customers can no longer perform DNS operations.'
+      message: "Designate API is not available"
+  
+  - alert: os_cinder_api_availability
+    expr: openstack_cinder_up != 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: 'The Cinder API is unavailable for over five minutes. This means customers cannot create volumes (e.g. for VMs).'
+      message: "Cinder API is not available"
+  
+  - alert: os_octavia_api_availability
+    expr: openstack_loadbalancer_up != 1
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: 'The Octavia API is unavailable for over five minutes. This means customers cannot create load balancers.'
+      message: "Octavia API is not available"
+  
+  - alert: os_nova_instance_limit_near_full
+    expr: 100 - ((openstack_nova_limits_instances_used / openstack_nova_limits_instances_max{tenant!~"kdtrial.+|kd500884.+|kd500770-demo.+"})*100) < 20
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      description: 'Number of Instances of Tenant {{ $labels.tenant }} with Tenant-ID {{ $labels.tenant_id }} Quota less then 80% '
+      message: "Instance Quota of {{ $labels.tenant }} nearly reached"
 
-
+  - alert: os_nova_vcpu_limit_near_full
+    expr: 100 - ((openstack_nova_limits_vcpus_used / openstack_nova_limits_vcpus_max{tenant!~"kdtrial.+|kd500884.+|kd500770-demo.+"})*100) < 20
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      description: Number of VCPUs of Tenant {{ $labels.tenant }} with Tenant-ID {{ $labels.tenant_id }} Quota less then 80%'
+      message: "VCPU Quota of {{ $labels.tenant }} nearly reached"
+  
+  - alert: os_nova_memory_limit_near_full
+    expr: 100 - ((openstack_nova_limits_memory_used / openstack_nova_limits_memory_max{tenant!~"kdtrial.+|kd500884.+|kd500770-demo.+"})*100) < 20
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      description: 'Memory of Tenant {{ $labels.tenant }} with Tenant-ID {{ $labels.tenant_id }} Quota less then 80%'
+      message: "Memory Quota of {{ $labels.tenant }} nearly reached"
+  
+  - alert: os_nova_instance_limit
+    expr: openstack_nova_limits_instances_max == openstack_nova_limits_instances_used{tenant!~"kdtrial.+|kd500884.+|kd500770-demo.+"}
+    for: 2h
+    labels:
+      severity: warning
+    annotations:
+      description: 'Number of Instances of Tenant {{ $labels.tenant }} with Tenant-ID {{ $labels.tenant_id }} is on Quota Limit for 2h. '
+      message: "Instance Quota of {{ $labels.tenant }} reached"
+  
+  - alert: os_nova_vcpu_limit
+    expr: openstack_nova_limits_vcpus_max == openstack_nova_limits_vcpus_used{tenant!~"kdtrial.+|kd500884.+|kd500770-demo.+"}
+    for: 2h
+    labels:
+      severity: warning
+    annotations:
+      description: 'Number of VCPUs of Tenant {{ $labels.tenant }} with Tenant-ID {{ $labels.tenant_id }} is on Quota Limit for 2h.'
+      message: "VCPU Quota of {{ $labels.tenant }} reached"
+  
+  - alert: os_nova_memory_limit
+    expr: openstack_nova_limits_memory_max == openstack_nova_limits_memory_used{tenant!~"kdtrial.+|kd500884.+|kd500770-demo.+"}
+    for: 2h
+    labels:
+      severity: warning
+    annotations:
+      description: 'Memory of Tenant {{ $labels.tenant }} with Tenant-ID {{ $labels.tenant_id }} is on Quota Limit for 2h.'
+      message: "Memory Quota of {{ $labels.tenant }} reached"
+  
+  - alert: os_nova_storage_limit_near_full
+    expr: 100 - ((openstack_cinder_limits_volume_used_gb / openstack_cinder_limits_volume_max_gb{tenant!~"kdtrial.+|kd500884.+|kd500770-demo.+"})*100) < 20
+    for: 30m
+    labels:
+      severity: warning
+    annotations:
+      description: 'Storage Quota of Tenant {{ $labels.tenant }} with Tenant-ID {{ $labels.tenant_id }} Quota less then 80%'
+      message: "Storage Quota of {{ $labels.tenant }} nearly reached"
+  
+  - alert: os_near_out_of_floating_IP
+    expr: sum(openstack_neutron_network_ip_availabilities_total{network_name=~"ext.*"} - openstack_neutron_network_ip_availabilities_used{network_name=~"ext.*"}) < 30
+    for: 1h
+    labels:
+      severity: warning
+    annotations:
+      description: 'There are fewer than 15 floating IPs available. Please check whether floating IPs can be released'
+      message: "Less then 15 Floating IPs left"
+  
+  - alert: os_out_of_floating_IP
+    expr: sum(openstack_neutron_network_ip_availabilities_total{network_name=~"ext.*"} - openstack_neutron_network_ip_availabilities_used{network_name=~"ext.*"}) < 10
+    for: 1h
+    labels:
+      severity: critical
+    annotations:
+      description: 'There are fewer than 5 floating IPs available. Please urgently check whether floating IPs can be released'
+      message: "Less then 5 Floating IPs left"
+  
+  - alert: PrometheusTargetMissing
+    expr: up == 0
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: 'The exporter {{ $labels.job }} on {{ $labels.instance }} is down. Please check and, if necessary, restart using docker start/restart.'
+      message: "Prometheus target missing instance {{ $labels.instance }} exporter {{ $labels.job }}"
+  
+  - alert: OpenstackNeutronAgentState
+    expr: openstack_neutron_agent_state == 0
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: '{{ $labels.service }} on {{ $labels.hostname }} is down. Please check. If necessary, restart the container using docker start/restart.'
+      message: "{{ $labels.service }} on {{ $labels.hostname }} down"
+  
+  - alert: OpenstackNovaAgentState
+    expr: openstack_nova_agent_state == 0
+    for: 5m
+    labels:
+      severity: critical
+    annotations:
+      description: '{{ $labels.service }} on {{ $labels.hostname }} is down. Please check. If necessary, restart the container using docker start/restart.'
+      message: "{{ $labels.service }} on {{ $labels.hostname }} is down"
+  
+  - alert: LoadbalancerNotActive
+    expr: openstack_loadbalancer_loadbalancer_status{provisioning_status!="ACTIVE"}
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      description: '{{ $labels.name }} in projekt {{ $labels.project_id }} in provisioning_status {{ $labels.provisioning_status }}.'
+      message: "{{ $labels.name }} in project {{ $labels.project_id }} in provisioning_status {{ $labels.provisioning_status }}"
+  
+  - alert: CinderVolumeStuck
+    expr: openstack_cinder_volume_status_counter{status=~"detaching|attaching|deleting|creating|error"} > 0
+    for: 15m
+    labels:
+      severity: warning
+    annotations:
+      description: 'There is at least one volume in state {{ $labels.status }} for longer than 15 minutes.'
+      message: "There is at least one volumes in state {{ $labels.status }} for longer than 15 minutes."

--- a/prometheus/prometheus.yml.d/60-fluentd-aggregator.yml
+++ b/prometheus/prometheus.yml.d/60-fluentd-aggregator.yml
@@ -1,0 +1,9 @@
+{% if groups.get('monitoring') %}
+scrape_configs:
+  - job_name: fluent_exporter
+    static_configs:
+      - targets:
+{% for host in groups['monitoring'] %}
+        - "{{ groups['monitoring'][0] }}:24231"
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
Signed-off-by: Aleksandr Gerasimenko <aleksandr.gerasimenko@plusserver.com>

This commit has next changes:

- grafana dashboards:

    (changed) ceph-cluster-advanced.json:
        "Added graph with title "Bad PGs". This graph helps to show PGs without ACTIVE and CLEAN status.
        It separates view from major active, clean PGs and point out PGs with "bad" status at the moment."

    (added) ceph_overview.json:
        "This dashboard shows the top clients to ceph with read/write and throuput."

    (added) ceph_pools.json:
        "This dashboard shows the best of two other dashboards: 'ceph-cluster.json' and 'ceph-cluster-advanced.json'."

- prometheus rules:

    (changed) ceph.rules:
        "Added group of rules Ceph Latency."

    (changed) haproxy.rules:
        "Added rules for backends, including Ceph Dashboard."

    (changed) mysql.rules:
        "Added rules for mariadb and slow logs."

    (changed) openstack.rules:
        "Added rules for OpenStack services, like: Cinder, Nova, Neutron, Keystone, Designate, Octavia etc."

    (added) container.rules:
        "Added rules related to containers life."

    (added) fluentd-aggregator.rules:
        "Added rules for fluentd aggregator.
        fluentd-aggregator could help to forward the logs from OpenStack cluster to company's centralized log system."
    In addition added '60-fluentd-aggregator.yml' jinja2 template and changed .yamllint.yml.

    (added) hardware.rules:
        "Added rules related to generic hardware."