### PR TITLE
Remove alert rule ContainerVolumeUsage

### DIFF
--- a/prometheus/cadvisor.rules
+++ b/prometheus/cadvisor.rules
@@ -40,14 +40,15 @@ groups:
         summary: Container High Memory usage (instance {{ $labels.instance }})
         description: "Container Memory usage is above 80%\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
-    - alert: ContainerVolumeUsage
-      expr: '(1 - (sum(container_fs_inodes_free{name!=""}) BY (instance) / sum(container_fs_inodes_total) BY (instance))) * 100 > 80'
-      for: 2m
-      labels:
-        severity: warning
-      annotations:
-        summary: Container Volume usage (instance {{ $labels.instance }})
-        description: "Container Volume usage is above 80%\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+# NOTE: disabled due to https://github.com/google/cadvisor/issues/3534
+#     - alert: ContainerVolumeUsage
+#       expr: '(1 - (sum(container_fs_inodes_free{name!=""}) BY (instance) / sum(container_fs_inodes_total) BY (instance))) * 100 > 80'
+#       for: 2m
+#       labels:
+#         severity: warning
+#       annotations:
+#         summary: Container Volume usage (instance {{ $labels.instance }})
+#         description: "Container Volume usage is above 80%\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
     - alert: ContainerHighThrottleRate
       expr: 'rate(container_cpu_cfs_throttled_seconds_total[3m]) > 1'


### PR DESCRIPTION
At least with storage-driver `overlay2` the metric `container_fs_inodes_free` shows zero for all containers.

See https://github.com/google/cadvisor/issues/3534

Part of https://github.com/osism/issues/issues/1009