### PR TITLE
Remove alert `HAproxyHttpSlowingDown`

### DIFF
--- a/prometheus/haproxy.rules
+++ b/prometheus/haproxy.rules
@@ -87,17 +87,16 @@ groups:
         summary: HAProxy pending requests (instance {{ $labels.instance }})
         description: "Some HAProxy requests are pending on {{ $labels.proxy }} - {{ $value | printf \"%.2f\"}}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
-# NOTE: The following alert has been changed from upstream because of
+# NOTE: The following alert is not being used because of
 #        https://github.com/samber/awesome-prometheus-alerts/issues/421
-    - alert: HaproxyHttpSlowingDown
-      # expr: 'avg by (instance, proxy) (haproxy_backend_max_total_time_seconds) > 1'
-      expr: 'haproxy_backend_total_time_average_seconds > 1'
-      for: 1m
-      labels:
-        severity: warning
-      annotations:
-        summary: HAProxy HTTP slowing down (instance {{ $labels.instance }})
-        description: "Average request time is increasing - {{ $value | printf \"%.2f\"}}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
+#     - alert: HaproxyHttpSlowingDown
+#       expr: 'avg by (instance, proxy) (haproxy_backend_max_total_time_seconds) > 1'
+#       for: 1m
+#       labels:
+#         severity: warning
+#       annotations:
+#         summary: HAProxy HTTP slowing down (instance {{ $labels.instance }})
+#         description: "Average request time is increasing - {{ $value | printf \"%.2f\"}}\n  VALUE = {{ $value }}\n  LABELS = {{ $labels }}"
 
     - alert: HaproxyRetryHigh
       expr: 'sum by (proxy) (rate(haproxy_backend_retry_warnings_total[1m])) > 10'


### PR DESCRIPTION
Although the alert was improved from the upstream version to make more sense it is still difficult to provide a good default, since response times are dependent on the individual deployment.
Therfore it is removed from this repository.