### PR TITLE
Increase timeout for ContainerKilled alert

### DIFF
--- a/prometheus/cadvisor.rules
+++ b/prometheus/cadvisor.rules
@@ -5,7 +5,10 @@ groups:
   rules:
 
     - alert: ContainerKilled
-      expr: 'time() - container_last_seen > 60'
+      # NOTE: increase timeout because default scrape interval is 60s and cadvisor housekeeping interval is set to scrape interval,
+      # leading to flapping alerts
+      # expr: 'time() - container_last_seen > 60'
+      expr: 'time() - container_last_seen > 120'
       for: 0m
       labels:
         severity: warning


### PR DESCRIPTION
In kolla-ansible the default scrape interval is 60s, which is also the housekeeping interval set for cadvisor and the timeout for the alert when compared to prometheus' time() query.
Since there are reports of the alert flapping its timeout is increased to 120s.

Closes: https://github.com/osism/issues/issues/1201