### PR TITLE
Remove superfluous fluent_exporter job

### DIFF
--- a/prometheus/prometheus.yml.d/60-fluentd-aggregator.yml
+++ b/prometheus/prometheus.yml.d/60-fluentd-aggregator.yml
@@ -1,9 +1,0 @@
-{% if groups.get('monitoring') %}
-scrape_configs:
-  - job_name: fluent_exporter
-    static_configs:
-      - targets:
-{% for host in groups['monitoring'] %}
-        - "{{ groups['monitoring'][0] }}:24231"
-{% endfor %}
-{% endif %}


### PR DESCRIPTION
1. Scraping the first node of the monitoring group for all nodes in the monitoring group does not make sense
2. A job scraping the exporter on all fluentd hosts is already part of kolla's default prometheus.yml template ([1])

[1]
https://review.opendev.org/c/openstack/kolla-ansible/+/785229

Closes: https://github.com/osism/issues/issues/1254